### PR TITLE
add missing requirement and fix some bugs

### DIFF
--- a/friday/agent/friday_agent.py
+++ b/friday/agent/friday_agent.py
@@ -10,6 +10,7 @@ from friday.core.utils import get_open_api_description_pair, get_open_api_doc_pa
 import re
 import json
 import logging
+from pathlib import Path
 
 class FridayAgent(BaseAgent):
     """ AI agent class, including planning, retrieval and execution modules """
@@ -801,6 +802,7 @@ class ExecutionModule(BaseAgent):
         """
         save str content to the specified path. 
         """
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
         with open(path, 'w', encoding='utf-8') as f:
             lines = content.strip().splitlines()
             content = '\n'.join(lines)

--- a/friday/core/action_manager.py
+++ b/friday/core/action_manager.py
@@ -20,6 +20,8 @@ class ActionManager:
 
         if not os.path.exists(self.vectordb_path):
             os.makedirs(self.vectordb_path)
+        os.makedirs(f"{action_lib_dir}/code", exist_ok=True)
+        os.makedirs(f"{action_lib_dir}/action_description", exist_ok=True)
         # Utilize the Chroma database and employ OpenAI Embeddings for vectorization (defaul: text-embedding-ada-002)
         self.vectordb = Chroma(
             collection_name="action_vectordb",

--- a/friday/environment/py_env.py
+++ b/friday/environment/py_env.py
@@ -32,7 +32,11 @@ class PythonEnv(Env):
         self.env_state = EnvState(command=_command)
         try:
             results = subprocess.run(
-                ["python", '-B', str(filename)],
+                [
+                    subprocess.run(["which", "python"], stdout=subprocess.PIPE).stdout.decode().strip(),
+                    '-B',
+                    str(filename)
+                ],
                 encoding="utf8",
                 check=True, cwd=self.working_dir, timeout=self.timeout,
                 stdout=subprocess.PIPE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,6 +92,7 @@ pydantic==2.5.2
 pydantic_core==2.14.5
 pyparsing==3.1.1
 PyPika==0.48.9
+pysqlite3==0.5.2
 python-dateutil==2.8.2
 python-docx==1.1.0
 python-dotenv==1.0.0


### PR DESCRIPTION
There was one missing requirement: `pysqlite3`.

Also some directory paths were not created, which led to failures when trying to write into them.

Finally, the python executable when `env={ "PYTHONPATH": os.getcwd()}` in `friday/environment/py_env.py:PythonEnv.step` is set was no the same one as the conda env; hence the need to run `which python` first to get the path to the actual executable (typically it could fall back to Python 2)